### PR TITLE
httprouter's Params are being discarded

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -24,6 +24,7 @@ type Context struct {
 	Output         *Output
 	Request        *http.Request
 	ResponseWriter http.ResponseWriter
+    Params   httprouter.Params
 }
 
 // New produces a new request context event.
@@ -34,6 +35,7 @@ func New(w http.ResponseWriter, req *http.Request, params httprouter.Params) *Co
 	c.Output = NewOutput(c)
 	c.Request = req
 	c.ResponseWriter = w
+    c.Params = params
 
 	if c.Input.Is("POST") || c.Input.Is("PUT") {
 		c.Input.Body()

--- a/router.go
+++ b/router.go
@@ -35,7 +35,7 @@ func (rns *RouteNamespace) Handle(method string, path string, handlers []Handler
 	// Serve the request
 	rns.server.router.Handle(method, path, func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		rns.DebugLogger.Printf(logprefix+"Capturing request; Route: %s:%s", method, path)
-		event := rns.server.captureRequest(w, req, nil, handlers)
+		event := rns.server.captureRequest(w, req, params, handlers)
 
 		for _, h := range handlers {
 			// TODO - Look into the context to see if we have already written headers


### PR DESCRIPTION
The Params never make it into the context object, so if you wanted to take advantage of httprouter's Param functions, you can't because they're not being passed along.